### PR TITLE
Modify variable declaration and format code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,17 +125,17 @@ IntPredicate flipFlop(IntPredicate fizz, IntPredicate buzz) {
 To define the flip-flop predicate, we call the method as follows.
 
 ```java
-IntPredicate fizzBuzz = flipFlop(fizz, buzz);
+var fizzBuzz = flipFlop(fizz, buzz);
 
- assertThat(numbers.filter(fizzBuzz))
-		 .as("Numbers between numbers divisible by three and by five")
-     .containsExactly(3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 18, 19, 20);
+assertThat(numbers.filter(fizzBuzz))
+        .as("Numbers between numbers divisible by three and by five")
+        .containsExactly(3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 18, 19, 20);
 ```
 
 To demonstrate the operation of this predicate, I enclosed the number sequences in square brackets.
 
 ```
-1, 2, **[3, 4, 5]**, **[6, 7, 8, 9, 10]**, 11, **[12, 13, 14, 15]**, 16, 17, **[18, 19, 20]**
+1, 2, [3, 4, 5], [6, 7, 8, 9, 10], 11, [12, 13, 14, 15], 16, 17, [18, 19, 20]
 ```
 
 We get a completely different sequence if we swap the predicates `fizz` and `buzz`.
@@ -151,7 +151,7 @@ assertThat(numbers.filter(buzzFizz))
 Please note that in this case, the number 15 begins and ends the sequence, and the number 20 starts the series, but we don’t have its completion. At the same time, we ignore the number 3, which should end the sequence since our sequence has not yet begun.
 
 ```
-1, 2, 3, 4, **[5, 6]**, 7, 8, 9, **[10, 11, 12]**, 13, 14, **[15]**, 16, 17, 18, 19, **[20**
+1, 2, 3, 4, [5, 6], 7, 8, 9, [10, 11, 12], 13, 14, [15], 16, 17, 18, 19, [20
 ```
 
 I hope you're willing to give the final problem a shot.


### PR DESCRIPTION
Altered explicit type declaration to "var", making the code cleaner and more modern as per the introduction of JEP 286 in JDK 10. Also, formatted the pieces of code and examples to improve readability, remove side distractions, and keep the focus solely on the logic. This modification does not change any operation or output of the code and tools, purely cosmetic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Documentation: Updated code examples in the README for better readability. The changes include using the `var` keyword instead of explicit type declarations and improving the alignment of assertions in test cases. These updates make the documentation easier to understand, especially for beginners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->